### PR TITLE
New version for openCARP packages, 23.3

### DIFF
--- a/var/spack/repos/builtin/packages/meshtool/package.py
+++ b/var/spack/repos/builtin/packages/meshtool/package.py
@@ -16,6 +16,7 @@ class Meshtool(MakefilePackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
+    version('oc', commit='6c5cfbd067120901f15a04bf63beec409bda6dc9')
     version('oc8.1', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
     version('oc7.0', commit="6c5cfbd067120901f15a04bf63beec409bda6dc9")
 

--- a/var/spack/repos/builtin/packages/opencarp/package.py
+++ b/var/spack/repos/builtin/packages/opencarp/package.py
@@ -18,7 +18,8 @@ class Opencarp(CMakePackage):
 
     maintainers = ['MarieHouillon']
 
-    version('8.1', commit='28eb2e97', submodules=False, no_cache=True, preferred=True)
+    version('', commit='4add5f67', submodules=False, no_cache=True, preferred=True)
+    version('8.1', commit='28eb2e97', submodules=False, no_cache=True)
     version('7.0', commit='78da9195', submodules=False, no_cache=True)
     version('master', branch='master', submodules=False, no_cache=True)
 
@@ -40,7 +41,7 @@ class Opencarp(CMakePackage):
     depends_on('py-carputils')
     depends_on('meshtool')
     # Use specific versions of carputils and meshtool for releases
-    for ver in ['7.0', '8.1']:
+    for ver in ['', '7.0', '8.1']:
         depends_on('py-carputils@oc' + ver, when='@' + ver + ' +carputils')
         depends_on('meshtool@oc' + ver, when='@' + ver + ' +meshtool')
 

--- a/var/spack/repos/builtin/packages/py-carputils/package.py
+++ b/var/spack/repos/builtin/packages/py-carputils/package.py
@@ -14,6 +14,7 @@ class PyCarputils(PythonPackage):
 
     version('master', branch='master')
     # Version to use with openCARP releases
+    version('oc', commit='')
     version('oc8.1', commit='a4210fcb0fe17226a1744ee9629f85b629decba3')
     version('oc7.0', commit='4c04db61744f2fb7665594d7c810699c5c55c77c')
 

--- a/var/spack/repos/builtin/packages/py-ipykernel/package.py
+++ b/var/spack/repos/builtin/packages/py-ipykernel/package.py
@@ -7,8 +7,10 @@
 class PyIpykernel(PythonPackage):
     """IPython Kernel for Jupyter"""
 
+    homepage = "https://github.com/ipython/ipykernel"
     pypi = "ipykernel/ipykernel-5.3.4.tar.gz"
 
+    version('6.4.1', sha256='df3355e5eec23126bc89767a676c5f0abfc7f4c3497d118c592b83b316e8c0cd')
     version('6.2.0',  sha256='4439459f171d77f35b7f7e72dace5d7c2dd10a5c9e2c22b173ad9048fbfe7656')
     version('6.0.2',  sha256='7fb3e370dbb481b012b74bed4e794d2d16eb2a83930b31e6d8d030b9fdb4d5b4')
     version('5.5.5',  sha256='e976751336b51082a89fc2099fb7f96ef20f535837c398df6eab1283c2070884')
@@ -32,8 +34,11 @@ class PyIpykernel(PythonPackage):
     depends_on('python@3.5:', when='@5.2:', type=('build', 'run'))
     depends_on('python@3.7:', when='@6.0:', type=('build', 'run'))
     depends_on('py-setuptools', type='build', when='@5:')
-    depends_on('py-importlib-metadata@:4', when='@6:^python@:3.7', type=('build', 'run'))
-    depends_on('py-argcomplete@1.12.3:', when='@6:^python@:3.7', type=('build', 'run'))
+    depends_on('py-ipython-genutils', when='@5.5.6', type=('build', 'run'))
+    depends_on('py-ipython-genutils', when='@6.3.1:', type=('build', 'run'))
+    depends_on('py-importlib-metadata@:3', when='@6:^python@:3.7', type=('build', 'run'))
+    depends_on('py-importlib-metadata@:4', when='@6.1:^python@:3.7', type=('build', 'run'))
+    depends_on('py-argcomplete@1.12.3:', when='@6.1:^python@:3.7', type=('build', 'run'))
     depends_on('py-debugpy@1.0:1', when='@6:', type=('build', 'run'))
     depends_on('py-ipython@4.0:', when='@:4', type=('build', 'run'))
     depends_on('py-ipython@5.0:', when='@5', type=('build', 'run'))
@@ -41,10 +46,12 @@ class PyIpykernel(PythonPackage):
     depends_on('py-traitlets@4.1.0:', type=('build', 'run'))
     depends_on('py-traitlets@4.1.0:5', when='@6:', type=('build', 'run'))
     depends_on('py-jupyter-client', type=('build', 'run'))
-    depends_on('py-jupyter-client@:7', when='@6:', type=('build', 'run'))
+    depends_on('py-jupyter-client@:6', when='@6.0.2:', type=('build', 'run'))
+    depends_on('py-jupyter-client@:7', when='@6.2:', type=('build', 'run'))
     depends_on('py-tornado@4.0:', when='@:4', type=('build', 'run'))
     depends_on('py-tornado@4.2:', when='@5', type=('build', 'run'))
     depends_on('py-tornado@4.2:6', when='@6:', type=('build', 'run'))
+    depends_on('py-matplotlib-inline@0.1.0:0.1', when='@6:', type=('build', 'run'))
     depends_on('py-appnope', when='platform=darwin', type=('build', 'run'))
 
     phases = ['build', 'install', 'install_data']

--- a/var/spack/repos/builtin/packages/py-jupyter-client/package.py
+++ b/var/spack/repos/builtin/packages/py-jupyter-client/package.py
@@ -10,6 +10,7 @@ class PyJupyterClient(PythonPackage):
     homepage = "https://github.com/jupyter/jupyter_client"
     pypi = "jupyter-client/jupyter_client-6.1.7.tar.gz"
 
+    version('7.0.6', sha256='8b6e06000eb9399775e0a55c52df6c1be4766666209c22f90c2691ded0e338dc')
     version('6.1.12', sha256='c4bca1d0846186ca8be97f4d2fa6d2bae889cce4892a167ffa1ba6bd1f73e782')
     version('6.1.7', sha256='49e390b36fe4b4226724704ea28d9fb903f1a3601b6882ce3105221cd09377a1')
     version('5.3.4', sha256='60e6faec1031d63df57f1cc671ed673dced0ed420f4377ea33db37b1c188b910')
@@ -26,6 +27,7 @@ class PyJupyterClient(PythonPackage):
     depends_on('python@2.7:2.8,3.3:', type=('build', 'run'))
     depends_on('python@2.7:2.8,3.5:', type=('build', 'run'), when='@5:')
     depends_on('python@3.5:', type=('build', 'run'), when='@6:')
+    depends_on('python@3.6.1:', type=('build', 'run'), when='@6.2:')
     depends_on('py-setuptools', type=('build', 'run'), when='@5:')
     depends_on('py-traitlets', type=('build', 'run'))
     depends_on('py-jupyter-core', type=('build', 'run'))
@@ -33,3 +35,5 @@ class PyJupyterClient(PythonPackage):
     depends_on('py-pyzmq@13:', type=('build', 'run'))
     depends_on('py-python-dateutil@2.1:', type=('build', 'run'), when='@5:')
     depends_on('py-tornado@4.1:', type=('build', 'run'), when='@5:')
+    depends_on('py-nest-asyncio@1.5:', type=('build', 'run'), when='@6.1.13:')
+    depends_on('py-entrypoints', type=('build', 'run'), when='@7:')

--- a/var/spack/repos/builtin/packages/py-rdflib/package.py
+++ b/var/spack/repos/builtin/packages/py-rdflib/package.py
@@ -18,9 +18,12 @@ class PyRdflib(PythonPackage):
     homepage = "https://github.com/RDFLib/rdflib"
     pypi = "rdflib/rdflib-5.0.0.tar.gz"
 
+    version('6.0.2', sha256='6136ae056001474ee2aff5fc5b956e62a11c3a9c66bb0f3d9c0aaa5fbb56854e')
     version('5.0.0', sha256='78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155')
 
-    depends_on('py-setuptools', type='build')
-    depends_on('py-six', type=('build', 'run'))
+    depends_on('python@3.7:', when='@6:', type='build')
+    depends_on('py-setuptools', when='@:5', type='build')
+    depends_on('py-setuptools', when='@6:', type=('build', 'run'))
     depends_on('py-pyparsing', type=('build', 'run'))
     depends_on('py-isodate', type=('build', 'run'))
+    depends_on('py-six', when='@:5', type=('build', 'run'))

--- a/var/spack/repos/builtin/packages/py-setuptools/package.py
+++ b/var/spack/repos/builtin/packages/py-setuptools/package.py
@@ -13,6 +13,7 @@ class PySetuptools(PythonPackage):
     homepage = "https://github.com/pypa/setuptools"
     pypi = "setuptools/setuptools-57.4.0.tar.gz"
 
+    version('58.2.0', sha256='2c55bdb85d5bb460bd2e3b12052b677879cffcf46c0c688f2e5bf51d36001145')
     version('57.4.0', sha256='6bac238ffdf24e8806c61440e755192470352850f3419a52f26ffe0a1a64f465')
     version('57.1.0', sha256='cfca9c97e7eebbc8abe18d5e5e962a08dcad55bb63afddd82d681de4d22a597b')
     version('51.0.0', sha256='029c49fd713e9230f6a41c0298e6e1f5839f2cde7104c0ad5e053a37777e7688')


### PR DESCRIPTION
Add a new version for the packages of the openCARP ecosystem, opencarp, meshtool and py-carputils.